### PR TITLE
Add support for TGV Lyria

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # sncf-smart-location
 
-Once connected on train Wi-Fi, display speed, max speed and name of current railway where your train (TGV or Intercités) is located.
+Once connected on train Wi-Fi, display speed, max speed and name of current railway where your train (TGV INOUI, Intercités or TGV Lyria) is located.
 
 Based on OpenStreetMap data, using Overpass-API
 
 ## Prerequisites
 
-You need to be connected to the Wi-Fi hotspot of your train (`_SNCF_WIFI_INTERCITES` or  `_SNCF_WIFI_INOUI`)  
+You need to be connected to the Wi-Fi hotspot of your train (`_SNCF_WIFI_INTERCITES`,  `_SNCF_WIFI_INOUI` or `_WIFI_LYRIA` ).  
 Make sure you have been authenticated through the `wifi.sncf` portal.
 
 ## Usage
+
+### TGV INOUI or Intercités
 
 Run with
 
@@ -17,4 +19,8 @@ Run with
 $ bash sncf-smart-location.sh
 ```
 
+### TGV Lyria
+```
+$ bash sncf-smart-location.sh --lyria
+```
 

--- a/sncf-smart-location.sh
+++ b/sncf-smart-location.sh
@@ -1,4 +1,10 @@
-curl https://wifi.sncf/router/api/train/gps -s > gps ;
+if [[ "$*" == *"--lyria"* ]]
+then
+    url_root="wifi.tgv-lyria.com"
+else
+    url_root="wifi.sncf"
+fi
+curl "https://$url_root/router/api/train/gps" -s > gps ;
 curl -s --data-urlencode "$(echo `echo 'data=way[railway](around:20,' ; cat gps | cut -d, -f4,5 | cut -d\" -f 3,5 | tr -d \": ; echo -n ');(._;>;);out;'  `)" https://overpass-api.de/api/interpreter \
 | grep 'maxspeed\|description\|name' ;
 speed=$(cat gps | cut -d, -f7 | cut -d: -f2)


### PR DESCRIPTION
These commits add support to display speed and location while connected on the TGV Lyria Wi-Fi hotspot.  
You need to add the `--lyria` argument if you are on a TGV Lyria because the web address of the API is different.
