### PR TITLE
Update TGV Lyria to match URL of new onboard service

### DIFF
--- a/sncf-smart-location.sh
+++ b/sncf-smart-location.sh
@@ -169,7 +169,7 @@ CURRENT_SSID=$(nmcli device wifi show-password | awk '/SSID/ {print $2}')
 case $CURRENT_SSID in
   *"INTERCITES"*) determine_intercites_type ;;
   *"INOUI"*) url_root="wifi.sncf/router/api/train/gps"; log "$MSG_CONNECTED_TGV_INOUI";;
-  *"LYRIA"*) url_root="wifi.tgv-lyria.com/router/api/train/gps"; log "$MSG_CONNECTED_LYRIA";;
+  *"LYRIA"*) url_root="wifi.tgv-lyria.com/api/train/gps/position/"; log "$MSG_CONNECTED_LYRIA";;
   *"OUIFI"*) url_root="ouifi.ouigo.com:8084/api/gps"; log "$MSG_CONNECTED_OUIGO";;
 esac
 


### PR DESCRIPTION
This PR fixes #2.

Even though the API address has changed, the structure of the response JSON is similar in the new UI (see below).

<img width="597" height="641" alt="{12E57E1C-CD9E-478C-91A9-D6C1838B9BB2}" src="https://github.com/user-attachments/assets/428b80fd-04ea-4f50-acac-11b378440fb5" />

<img width="596" height="216" alt="{D26D9A83-BF33-46A9-BC73-F7CD4C4FA146}" src="https://github.com/user-attachments/assets/9bad9d59-198a-48a1-9679-99e7f83b710f" />

